### PR TITLE
FEATURE Add support for calculatedValue fields

### DIFF
--- a/src/Divante/ObjectMapperBundle/Helper/MapperHelper.php
+++ b/src/Divante/ObjectMapperBundle/Helper/MapperHelper.php
@@ -16,7 +16,7 @@ class MapperHelper
 {
     const OBJECT_TYPE_PRODUCT = 'product';
     const OBJECT_TYPE_CATEGORY = 'category';
-    const TEXT_TYPES = ['input', 'numeric', 'country', 'language'];
+    const TEXT_TYPES = ['input', 'numeric', 'country', 'language', 'calculatedValue'];
     const TEXT_AREA_TYPES = ['textarea'];
     const WYSIWYG_TYPES   = ['wysiwyg'];
     const DATE_TYPES = ['date', 'datetime', 'time'];


### PR DESCRIPTION
Add support for calculated value fields in sync to Magento. Since calculated fields are really only text fields whose value are calculated when the getter is called, this was a very simple thing to implement. All that has been done is to add calculatedValue to the TEXT_TYPES array in MapperHelper