### PR TITLE
Assetlistener must be public

### DIFF
--- a/src/Divante/MagentoIntegrationBundle/Resources/config/listeners.yml
+++ b/src/Divante/MagentoIntegrationBundle/Resources/config/listeners.yml
@@ -21,6 +21,7 @@ services:
   Divante\MagentoIntegrationBundle\EventListener\AssetListener:
     tags:
     - { name: kernel.event_listener, event: pimcore.asset.postUpdate, method: onPostAssetUpdate, priority: 50 }
+    public: true
 
 
   Divante\MagentoIntegrationBundle\EventListener\DeleteObjectEventListener:


### PR DESCRIPTION
If i sync assets on the magento site, when the request to webservice/rest/asset/update-status is made i get the following error: `{"msg":"Asset status could not be updates","success":false}`. Pimcore logs the following `The "Divante\MagentoIntegrationBundle\EventListener\AssetListener" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.`

As far as I understand it, symfony only registers services in the container that are public, so when the listener is removed [here](https://github.com/DivanteLtd/pimcore-magento2-bridge/blob/master/src/Divante/MagentoIntegrationBundle/Service/Asset/AssetStatusService.php#L41) the container throws an exception. 
