### PR TITLE
Fix invalid attribute code characters by replacing "&" with "_"

### DIFF
--- a/src/Application/Mapper/MapperService.php
+++ b/src/Application/Mapper/MapperService.php
@@ -343,8 +343,8 @@ class MapperService
                 $element = $object->elements->{$attribute};
                 unset($object->elements->{$attribute});
                 $object->elements->{$attribute . '_conf'} = $element;
-                $modifiedAttributesArray[]                = $attribute . '_conf';
             }
+            $modifiedAttributesArray[] = $attribute . '_conf';
         }
         $modifiedAttributes = implode(',', $modifiedAttributesArray);
         if (!$object->properties) {

--- a/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
+++ b/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
@@ -71,7 +71,9 @@ abstract class AbstractMapKeyStrategy implements MapKeyStrategyInterface
         } else {
             $names = [$name];
         }
-        return str_replace(' ', '', str_replace('-', '_', array_map('strtolower', $names)));
+        $code = str_replace(' ', '', str_replace('-', '_', array_map('strtolower', $names)));
+        $code = str_replace(['å','ä'], 'a', str_replace('ö', 'o', $code));
+        return $code;
     }
 
     /**

--- a/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
+++ b/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
@@ -73,6 +73,8 @@ abstract class AbstractMapKeyStrategy implements MapKeyStrategyInterface
         }
         $code = str_replace(' ', '', str_replace('-', '_', array_map('strtolower', $names)));
         $code = str_replace(['å','ä'], 'a', str_replace('ö', 'o', $code));
+        $code = str_replace("&", "_", $code);
+        
         return $code;
     }
 

--- a/src/Application/Mapper/Strategy/ClassificationStore/MapSelectKey.php
+++ b/src/Application/Mapper/Strategy/ClassificationStore/MapSelectKey.php
@@ -40,9 +40,6 @@ class MapSelectKey extends AbstractMapKeyStrategy
     ): void {
         $names         = $this->mapStringNames($attribute['name'], $group['name'], $arrayMapping);
         $valuesWithKey = $this->getFieldValue($field, $attribute, $language);
-        if (!$valuesWithKey) {
-            return;
-        }
         $parsedData = [
             'type'  => MapSelectValue::TYPE,
             'label' => $this->getLabel($field->getTitle(), $language),

--- a/src/Application/Mapper/Strategy/ClassificationStore/MapSelectKey.php
+++ b/src/Application/Mapper/Strategy/ClassificationStore/MapSelectKey.php
@@ -46,7 +46,7 @@ class MapSelectKey extends AbstractMapKeyStrategy
             'value' => $valuesWithKey
         ];
         
-        if (count($valuesWithKey) == 1) {
+        if ($field->getType() == 'select') {
             $parsedData['value'] = $parsedData['value'][0];
             $parsedData['type']  = self::SINGLE_TYPE;
         } else {

--- a/src/Application/Mapper/Strategy/MapMultiObjectValue.php
+++ b/src/Application/Mapper/Strategy/MapMultiObjectValue.php
@@ -33,9 +33,6 @@ class MapMultiObjectValue extends AbstractMapStrategy
      */
     public function map(Element $field, \stdClass &$obj, array $arrayMapping, $language, $definition, $outObject): void
     {
-        if (!$field->value) {
-            return;
-        }
         $names      = $this->getFieldNames($field, $arrayMapping);
         $parsedData = [
             'type'  => self::TYPE,

--- a/src/Application/Mapper/Strategy/MapMultiSelectValue.php
+++ b/src/Application/Mapper/Strategy/MapMultiSelectValue.php
@@ -31,9 +31,6 @@ class MapMultiSelectValue extends MapTextValue
      */
     public function map(Element $field, \stdClass &$obj, array $arrayMapping, $language, $definition, $outObject): void
     {
-        if (!$field->value) {
-            return;
-        }
         $names = $this->getFieldNames($field, $arrayMapping);
         $parsedData = [
             'value' => $this->getFieldValues($field, $language),
@@ -55,13 +52,15 @@ class MapMultiSelectValue extends MapTextValue
     protected function getFieldValues(Element $field, $language)
     {
         $values = [];
-        foreach ($field->value as $value) {
-            $key = is_array($value) ? $value['key'] : $value;
-            $values[] =
-                (object)[
-                    'key'   => $this->translator->trans($key, [], null, $language),
-                    'value' => is_array($value) ? $value['value'] : $value
-                ];
+        if (is_iterable($field->value)) {
+            foreach ($field->value as $value) {
+                $key = is_array($value) ? $value['key'] : $value;
+                $values[] =
+                    (object)[
+                        'key'   => $this->translator->trans($key, [], null, $language),
+                        'value' => is_array($value) ? $value['value'] : $value
+                    ];
+            }
         }
         return $values;
     }


### PR DESCRIPTION
Adjusted the magento bridge to not allow invalid characters such as "&" to be allowed within attribute codes and instead be replaced with "_".